### PR TITLE
Parse DenseNodes before Ways and Relations

### DIFF
--- a/src.java/crosby/binary/BinaryParser.java
+++ b/src.java/crosby/binary/BinaryParser.java
@@ -118,10 +118,11 @@ public abstract class BinaryParser implements BlockReaderAdapter {
                 .getPrimitivegroupList()) {
             // Exactly one of these should trigger on each loop.
             parseNodes(groupmessage.getNodesList());
+            if (groupmessage.hasDense())
+                parseDense(groupmessage.getDense());            
             parseWays(groupmessage.getWaysList());
             parseRelations(groupmessage.getRelationsList());
-            if (groupmessage.hasDense())
-                parseDense(groupmessage.getDense());
+
         }
     }
     


### PR DESCRIPTION
Parse DenseNodes before Ways and possibly trying to solve Node references in Ways.