### PR TITLE
Create OsmpbfConfig.cmake to simplify locating library from within CMake-based projects

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,3 +17,6 @@ SET(INCLUDE_INSTALL "include/osmpbf")
 SET(files ${CMAKE_SOURCE_DIR}/include/osmpbf/osmpbf.h ${CMAKE_BINARY_DIR}/src/osmformat.pb.h ${CMAKE_BINARY_DIR}/src/fileformat.pb.h)
 INSTALL(FILES ${files} DESTINATION ${INCLUDE_INSTALL})
 install(TARGETS osmpbf LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+
+configure_file("OsmpbfConfig.cmake.in" "OsmpbfConfig.cmake" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/OsmpbfConfig.cmake" DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/Osmpbf/)

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,7 @@ CXXFLAGS += -Wall -Wextra -pedantic -Wredundant-decls -Wdisabled-optimization -W
 
 .PHONY: clean install
 
-all: libosmpbf.a libosmpbf.so ../include/osmpbf/fileformat.pb.h ../include/osmpbf/osmformat.pb.h
+all: libosmpbf.a libosmpbf.so ../include/osmpbf/fileformat.pb.h ../include/osmpbf/osmformat.pb.h OsmpbfConfig.cmake
 
 libosmpbf.a: fileformat.pb.o osmformat.pb.o
 	$(AR) -cr $@ fileformat.pb.o osmformat.pb.o
@@ -28,6 +28,12 @@ libosmpbf.so: fileformat.pb.o osmformat.pb.o
 	$(PROTOC) --proto_path=. --cpp_out=. $<
 	cp -v $(subst .proto,.pb.h,$<) ../include/osmpbf/
 
+%: %.in
+	# The placeholder for the installation prefix is '@CMAKE_INSTALL_PREFIX@'.
+	# Do not change that, it would only make the CMakeLists.txt file which does
+	# the same job as below line more complex.
+	sed -e 's!@CMAKE_INSTALL_PREFIX@!'$(DESTDIR)$(PREFIX)'!g' <$< >$@
+
 install:
 	install -m 755 -d $(DESTDIR)$(LIBDIR)
 	install -m 644 libosmpbf.a $(DESTDIR)$(LIBDIR)
@@ -38,7 +44,9 @@ install:
 	install -m 644 ../include/osmpbf/osmpbf.h $(DESTDIR)$(PREFIX)/include/osmpbf
 	install -m 644 ../include/osmpbf/fileformat.pb.h $(DESTDIR)$(PREFIX)/include/osmpbf
 	install -m 644 ../include/osmpbf/osmformat.pb.h $(DESTDIR)$(PREFIX)/include/osmpbf
+	install -m 755 -d $(DESTDIR)$(PREFIX)/lib/cmake/Osmpbf
+	install -m 644 OsmpbfConfig.cmake $(DESTDIR)$(PREFIX)/lib/cmake/Osmpbf
 
 clean:
-	rm -f *.pb.h *.pb.cc *.pb.o libosmpbf.a
+	rm -f *.pb.h *.pb.cc *.pb.o libosmpbf.a OsmpbfConfig.cmake
 

--- a/src/OsmpbfConfig.cmake.in
+++ b/src/OsmpbfConfig.cmake.in
@@ -1,0 +1,2 @@
+set(OSMPBF_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include/osmpbf")
+set(OSMPBF_LIBRARIES "@CMAKE_INSTALL_PREFIX@/lib/libosmpbf.a")


### PR DESCRIPTION
The two commits of this pull request add the generation of a file OsmpbfConfig.cmake which greatly simplifies locating and using this Osmpbf library from within projects using CMake.

Commit eff2cde has a short explanation and example and generate the OsmpbfConfig.cmake when building Osmpbf through CMake.
Commit bdd69a1 does a similar job, but generates and installs the .cmake file when building the library using a plain 'make'.