### PR TITLE
Specify proto2 syntax to fix warnings with protobuf 3.0.0.

### DIFF
--- a/src/fileformat.proto
+++ b/src/fileformat.proto
@@ -15,6 +15,8 @@
 
 */
 
+syntax = "proto2";
+
 option optimize_for = LITE_RUNTIME;
 option java_package = "crosby.binary";
 package OSMPBF;

--- a/src/osmformat.proto
+++ b/src/osmformat.proto
@@ -15,6 +15,8 @@
 
 */
 
+syntax = "proto2";
+
 option optimize_for = LITE_RUNTIME;
 option java_package = "crosby.binary";
 package OSMPBF;


### PR DESCRIPTION
`protoc` from protobuf 3.0.0 warns about the missing syntax:
```
protoc --proto_path=. --cpp_out=. fileformat.proto
protoc --proto_path=. --cpp_out=. osmformat.proto
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: osmformat.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: fileformat.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```
Setting it explicitly is a good idea to not break when when the default changes in a future protobuf release.