### PR TITLE
Specifies the format in the protocol files.

### DIFF
--- a/src/fileformat.proto
+++ b/src/fileformat.proto
@@ -15,6 +15,7 @@
 
 */
 
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 option java_package = "crosby.binary";
 package OSMPBF;

--- a/src/osmformat.proto
+++ b/src/osmformat.proto
@@ -15,6 +15,7 @@
 
 */
 
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 option java_package = "crosby.binary";
 package OSMPBF;


### PR DESCRIPTION
Protobuf outputs a warning if not explicitly specified in the .proto
file.

This warning was introduced in this commit, back in 2014:
protocolbuffers/Protobuf@3eb55df6a4624f6124d96ea52a7c2915ee7957fd

This pull request changes the .proto files just adding the `syntax=` lines with `proto2` which is the _failover_ syntax it chooses anyway.